### PR TITLE
Default currency in money format

### DIFF
--- a/packages/tables/src/Columns/Concerns/CanFormatState.php
+++ b/packages/tables/src/Columns/Concerns/CanFormatState.php
@@ -135,7 +135,7 @@ trait CanFormatState
             }
 
             if (blank($currency)) {
-                $currency = config('money.default_currency') ?? 'usd';
+                $currency = env('DEFAULT_CURRENCY', 'USD');
             }
 
             return (new Money\Money(


### PR DESCRIPTION
_default_currency_ isn't into config file but in an environment variable : 
@see [laravel-money/src/helpers.php](https://github.com/akaunting/laravel-money/blob/cbc66d1dc457c169f6081e0ae6c661b499dad301/src/helpers.php#L11)